### PR TITLE
Fix 2130 initialization

### DIFF
--- a/src/modules/utils/motordrivercontrol/drivers/TMC21X/TMC21X.cpp
+++ b/src/modules/utils/motordrivercontrol/drivers/TMC21X/TMC21X.cpp
@@ -620,6 +620,8 @@
  */
 TMC21X::TMC21X(std::function<int(uint8_t *b, int cnt, uint8_t *r)> spi, char d) : spi(spi), designator(d)
 {
+	connection_method = StepstickParameters::SPI;
+    max_current= 2000; //TMC2130 supports upto 2A.
     //we are not started yet
     started = false;
     //by default cool step is not enabled


### PR DESCRIPTION
Currently only TMC220X, TMC26X and drv8711 have their `connection_method` initialized. Without it `TMC21X` which is a SPI chip, does not have a default connection method set. This fails to initialize the chip and gives and error `MotorDriverControl A ERROR: Unsupported connection method! Only SPI and UART supported.` with this config. 

```
## Motor driver configuration
motor_driver_control.driver.enable                 true            # Enable motor driver module
motor_driver_control.driver.axis                   A               # Axis designator on which the motor driver is set 
motor_driver_control.driver.chip                   TMC2130         # Motor driver chip type
motor_driver_control.driver.spi_channel            1               # Set corresponding pins of the selected spi channel
motor_driver_control.driver.spi_cs_pin             0.0             # Set chip select pin
motor_driver_control.driver.current               1000            # Motor currents in mA
motor_driver_control.driver.sense_resistor        110             # Sensing resistor value as a reference in milliohms
motor_driver_control.driver.microsteps            16              # Set microstepping value per step pulse. It can be 1, 2, 4, 8, 16, 32, 64, 128 or 256 microsteps
motor_driver_control.driver.chopper_mode          1               # 0 = stealthChop ; 1 = spreadCycle ; 2 = traditional constant off-time
```