### PR TITLE
Fix 2130

### DIFF
--- a/src/modules/utils/motordrivercontrol/drivers/TMC21X/TMC21X.cpp
+++ b/src/modules/utils/motordrivercontrol/drivers/TMC21X/TMC21X.cpp
@@ -1260,7 +1260,7 @@ void TMC21X::setCoolStepthreshold (uint32_t threshold)
     }
 }
 
-void TMC21X::set_current(unsigned int current)
+void TMC21X::set_current(uint16_t current)
 {
     uint8_t current_scaling = 0;
     //calculate the current scaling from the max current setting (in mA)

--- a/src/modules/utils/motordrivercontrol/drivers/TMC21X/TMC21X.cpp
+++ b/src/modules/utils/motordrivercontrol/drivers/TMC21X/TMC21X.cpp
@@ -1272,6 +1272,8 @@ void TMC21X::set_current(uint16_t current)
     //for vsense = 0,32V (VSENSE not set)
     //or vsense = 0,18V (VSENSE set)
     current_scaling = (uint8_t)((5.65685F * (resistor_value + 20) * mASetting / 1000.0F) / (125 * 0.32F) - 1);
+    //THEKERNEL->streams->printf("Current - %d, Final CS - %d",current, (uint16_t) current_scaling);
+    
     //check if the current scaling is too low
     if (current_scaling < 16) {
         //set the Vsense bit to get a use half the sense voltage (to support lower motor currents)
@@ -1494,7 +1496,7 @@ unsigned int TMC21X::getCoolstepCurrent(void)
     float result = (float)getCurrentCSReading();
     float resistor_value = (float)this->resistor;
     float voltage = (chopconf_register_value & CHOPCONF_VSENSE) ? 0.18F : 0.32F;
-    result = (result + 1.0F) / 32.0F * voltage / ((resistor_value + 20)*0.001F) * 707.10678F;git 
+    result = (result + 1.0F) / 32.0F * voltage / ((resistor_value + 20)*0.001F) * 707.10678F;
     return (unsigned int)roundf(result);
 }
 

--- a/src/modules/utils/motordrivercontrol/drivers/TMC21X/TMC21X.h
+++ b/src/modules/utils/motordrivercontrol/drivers/TMC21X/TMC21X.h
@@ -271,7 +271,7 @@ public:
      * \param current the maximum motor current in mA
      * \sa getCurrent(), getCurrentCurrent()
      */
-    void set_current(unsigned int current);
+    void set_current(uint16_t current);
 
     /*!
      * \brief set standstill motor current


### PR DESCRIPTION
TMC2130 code had wrong signature for `set_current`, instead of `set_current(uint16_t current)` it had `set_current(unsigned int current)` which made the initialization to skip setting current. So it was running with default 76mA of motor current. 

Another problem I found (which I think is there in 22X driver as well) is wrong formula used for current calculation. Current code missed the `∗ 1/√2` part in `set_current` 