### PR TITLE
Fix 2209

### DIFF
--- a/src/modules/utils/motordrivercontrol/MotorDriverControl.cpp
+++ b/src/modules/utils/motordrivercontrol/MotorDriverControl.cpp
@@ -148,7 +148,7 @@ bool MotorDriverControl::config_module(uint16_t cs)
         PinName rxd = NC;
         
         // Read/Write or Write-only mode?
-        if (THEKERNEL->config->value(motor_driver_control_checksum, cs, sw_uart_rx_pin_checksum)->by_default("nc")->as_string() != "NC" ) {            
+        if (THEKERNEL->config->value(motor_driver_control_checksum, cs, sw_uart_rx_pin_checksum)->by_default("nc")->as_string() != "nc" ) {            
             sw_uart_rx_pin->from_string(THEKERNEL->config->value(motor_driver_control_checksum, cs, sw_uart_rx_pin_checksum)->by_default("nc")->as_string())->as_input();
             if(!sw_uart_rx_pin->connected()) {
                 THEKERNEL->streams->printf("MotorDriverControl %c ERROR: cannot open RX PIN, falling back to writeonly!\n", axis);

--- a/src/modules/utils/motordrivercontrol/MotorDriverControl.cpp
+++ b/src/modules/utils/motordrivercontrol/MotorDriverControl.cpp
@@ -153,7 +153,11 @@ bool MotorDriverControl::config_module(uint16_t cs)
             if(!sw_uart_rx_pin->connected()) {
                 printf("MotorDriverControl %c ERROR: cannot open RX PIN, falling back to writeonly!\n", axis);
                 write_only = true;
-            } else {
+            }else if(!(sw_uart_rx_pin->port_number == 0 || sw_uart_rx_pin->port_number == 2)) {
+                printf("MotorDriverControl %c ERROR: RX PIN needs to be Interrupt enabled pin (Port 0 or 2), falling back to writeonly!\n", axis);
+                write_only = true;
+            } 
+            else {
                 rxd = port_pin((PortName)(sw_uart_rx_pin->port_number), sw_uart_rx_pin->pin);
                 write_only = false;
             }

--- a/src/modules/utils/motordrivercontrol/MotorDriverControl.cpp
+++ b/src/modules/utils/motordrivercontrol/MotorDriverControl.cpp
@@ -87,19 +87,19 @@ bool MotorDriverControl::config_module(uint16_t cs)
         // NOTE Deprecated use of designator for backward compatibility
         str= THEKERNEL->config->value( motor_driver_control_checksum, cs, designator_checksum)->by_default("")->as_string();
         if(str.empty()) {
-            THEKERNEL->streams->printf("MotorDriverControl ERROR: axis not defined\n");
+            printf("MotorDriverControl ERROR: axis not defined\n");
             return false; // axis/axis required
         }
     }
     axis= str[0];
     if( !((axis >= 'X' && axis <= 'Z') || (axis >= 'A' && axis <= 'C')) ) {
-        THEKERNEL->streams->printf("MotorDriverControl ERROR: axis must be one of XYZABC\n");
+        printf("MotorDriverControl ERROR: axis must be one of XYZABC\n");
         return false; // axis is illegal
     }
 
     str= THEKERNEL->config->value( motor_driver_control_checksum, cs, chip_checksum)->by_default("")->as_string();
     if(str.empty()) {
-        THEKERNEL->streams->printf("MotorDriverControl %c ERROR: chip type not defined\n", axis);
+        printf("MotorDriverControl %c ERROR: chip type not defined\n", axis);
         return false; // chip type required
     }
 
@@ -123,7 +123,7 @@ bool MotorDriverControl::config_module(uint16_t cs)
         chip= StepstickParameters::CHIP_TYPE::TMC2660;
         DRV= new TMC26X(std::bind( &MotorDriverControl::sendSPI, this, _1, _2, _3), axis);
     }else{
-        THEKERNEL->streams->printf("MotorDriverControl %c ERROR: Unknown chip type: %s\n", axis, str.c_str());
+        printf("MotorDriverControl %c ERROR: Unknown chip type: %s\n", axis, str.c_str());
         return false;
     }
 
@@ -140,7 +140,7 @@ bool MotorDriverControl::config_module(uint16_t cs)
         sw_uart_tx_pin->from_string(THEKERNEL->config->value(motor_driver_control_checksum, cs, sw_uart_tx_pin_checksum)->by_default("nc")->as_string())->as_output();
         
         if(!sw_uart_tx_pin->connected()) {
-            THEKERNEL->streams->printf("MotorDriverControl %c ERROR: uart tx pin not defined\n", axis);
+            printf("MotorDriverControl %c ERROR: uart tx pin not defined\n", axis);
             return false; 
         }
         
@@ -151,7 +151,7 @@ bool MotorDriverControl::config_module(uint16_t cs)
         if (THEKERNEL->config->value(motor_driver_control_checksum, cs, sw_uart_rx_pin_checksum)->by_default("nc")->as_string() != "nc" ) {            
             sw_uart_rx_pin->from_string(THEKERNEL->config->value(motor_driver_control_checksum, cs, sw_uart_rx_pin_checksum)->by_default("nc")->as_string())->as_input();
             if(!sw_uart_rx_pin->connected()) {
-                THEKERNEL->streams->printf("MotorDriverControl %c ERROR: cannot open RX PIN, falling back to writeonly!\n", axis);
+                printf("MotorDriverControl %c ERROR: cannot open RX PIN, falling back to writeonly!\n", axis);
                 write_only = true;
             } else {
                 rxd = port_pin((PortName)(sw_uart_rx_pin->port_number), sw_uart_rx_pin->pin);
@@ -177,7 +177,7 @@ bool MotorDriverControl::config_module(uint16_t cs)
         spi_cs_pin = new Pin();
         spi_cs_pin->from_string(THEKERNEL->config->value( motor_driver_control_checksum, cs, spi_cs_pin_checksum)->by_default("nc")->as_string())->as_output();
         if(!spi_cs_pin->connected()) {
-            THEKERNEL->streams->printf("MotorDriverControl %c ERROR: chip select not defined\n", axis);
+            printf("MotorDriverControl %c ERROR: chip select not defined\n", axis);
             return false; // if not defined then we can't use this instance
         }
         spi_cs_pin->set(1);
@@ -193,7 +193,7 @@ bool MotorDriverControl::config_module(uint16_t cs)
         } else if(spi_channel == 1) {
             mosi = P0_9; miso = P0_8; sclk = P0_7;
         } else {
-            THEKERNEL->streams->printf("MotorDriverControl %c ERROR: Unknown SPI Channel: %d\n", axis, spi_channel);
+            printf("MotorDriverControl %c ERROR: Unknown SPI Channel: %d\n", axis, spi_channel);
             return false;
         }
 
@@ -201,7 +201,7 @@ bool MotorDriverControl::config_module(uint16_t cs)
         this->spi->frequency(spi_frequency);
         this->spi->format(8, 3); // 8bit, mode3
     } else {
-        THEKERNEL->streams->printf("MotorDriverControl %c ERROR: Unsupported connection method! Only SPI and UART supported.\n", axis);
+        printf("MotorDriverControl %c ERROR: Unsupported connection method! Only SPI and UART supported.\n", axis);
         return false;
     }
 
@@ -248,9 +248,9 @@ bool MotorDriverControl::config_module(uint16_t cs)
 
     //finish driver setup
     if(DRV->connection_method== StepstickParameters::UART) {
-        THEKERNEL->streams->printf("MotorDriverControl INFO: configured motor %c (%d): as %s, tx: %04X, rx: %04X\n", axis, id, THEKERNEL->config->value( motor_driver_control_checksum, cs, chip_checksum)->by_default("")->as_string().c_str(), (sw_uart_tx_pin->port_number<<8)|sw_uart_tx_pin->pin, (sw_uart_rx_pin->port_number<<8)|sw_uart_rx_pin->pin);
+        printf("MotorDriverControl INFO: configured motor %c (%d): as %s, tx: %04X, rx: %04X\n", axis, id, THEKERNEL->config->value( motor_driver_control_checksum, cs, chip_checksum)->by_default("")->as_string().c_str(), (sw_uart_tx_pin->port_number<<8)|sw_uart_tx_pin->pin, (sw_uart_rx_pin->port_number<<8)|sw_uart_rx_pin->pin);
     } else {
-        THEKERNEL->streams->printf("MotorDriverControl INFO: configured motor %c (%d): as %s, cs: %04X\n", axis, id, THEKERNEL->config->value( motor_driver_control_checksum, cs, chip_checksum)->by_default("")->as_string().c_str(), (spi_cs_pin->port_number<<8)|spi_cs_pin->pin);
+        printf("MotorDriverControl INFO: configured motor %c (%d): as %s, cs: %04X\n", axis, id, THEKERNEL->config->value( motor_driver_control_checksum, cs, chip_checksum)->by_default("")->as_string().c_str(), (spi_cs_pin->port_number<<8)|spi_cs_pin->pin);
     }
 
     return true;
@@ -301,7 +301,7 @@ void MotorDriverControl::on_second_tick(void *argument)
 
     if(halt_on_alarm && alarm) {
         THEKERNEL->call_event(ON_HALT, nullptr);
-        THEKERNEL->streams->printf("Error: Motor Driver alarm - reset or M999 required to continue\r\n");
+        printf("Error: Motor Driver alarm - reset or M999 required to continue\r\n");
     }
 }
 


### PR DESCRIPTION
As mentioned in the [main PR conversation](https://github.com/Smoothieware/Smoothieware/pull/1447#issuecomment-667718005) there is a typo. If you try to use 2209 without RX pin, current code compares "nc" with "NC". 

Recently Jim has made changes in to main code to  update `streams->printf`, to just `printf`. This is flagged as a conflict in main PR.
